### PR TITLE
actions: updated to newest node version 20

### DIFF
--- a/.github/workflows/gradle.yml
+++ b/.github/workflows/gradle.yml
@@ -16,9 +16,9 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
       - name: Set up JDK 11
-        uses: actions/setup-java@v2
+        uses: actions/setup-java@v4
         with:
           java-version: '11'
           distribution: 'adopt'


### PR DESCRIPTION
We should update to the newes node version 20. See: https://github.blog/changelog/2023-09-22-github-actions-transitioning-from-node-16-to-node-20/