### PR TITLE
Support publishing a JBR by its corresponding MPS version

### DIFF
--- a/.github/workflows/gradle.yml
+++ b/.github/workflows/gradle.yml
@@ -1,11 +1,11 @@
 # This workflow will build a Java project with Gradle
 # For more information see: https://help.github.com/actions/language-and-framework-guides/building-and-testing-java-with-gradle
 
-name: Test publishing with a hardcoded version
+name: Test publishing
 
 on: [push]
 jobs:
-  build:
+  publish-by-jbr-version:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6
@@ -14,5 +14,17 @@ jobs:
         with:
           java-version: '17'
           distribution: 'temurin'
-      - name: Test publishing
-        run: ./gradlew publishToMavenLocal -PjdkVersion=21.0.4 -PjdkBuild=b631.2
+      - name: Test publishing with a hardcoded JBR version
+        run: ./gradlew publishToMavenLocal -PjbrVersion=21.0.4-b631.2
+
+  publish-by-mps-version:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+      - name: Set up JDK
+        uses: actions/setup-java@v5
+        with:
+          java-version: '17'
+          distribution: 'temurin'
+      - name: Test publishing with an MPS version
+        run: ./gradlew publishToMavenLocal -PmpsVersion=2025.1

--- a/README.md
+++ b/README.md
@@ -23,9 +23,31 @@ For more information, visit the [JetBrains runtime](https://github.com/JetBrains
 
 The script for older MPS versions can be found in the mps/**X** branches where **X** is a major MPS version.
 
-For publishing, run parametrized build in the CI providing `jdkVersion` and `jdkBuild` values for the JBR version to publish as project properties (see table below for examples).
+For publishing, trigger the parametrized build in CI and specify **either**:
+
+- `jbrVersion` — the full JBR version to publish, e.g. `21.0.6-b895.109` (see the table below); or
+- `mpsVersion` — an MPS release (e.g. `2025.1`) or pre-release build number (e.g. `261.25134.10210`). The matching JBR
+  version is looked up automatically from the `com.jetbrains.mps:mps-jbr` marker POM (see below). For releases this works
+  for MPS 2023.3.1 and later; for earlier MPS versions, pass `jbrVersion` directly.
+
+Set only one of the two. The legacy `jdkVersion` + `jdkBuild` properties are still accepted but deprecated in favor of
+`jbrVersion`.
+
+## Looking up the JBR for an MPS version
+
+Since MPS 2023.3.1, [build.publish.mps](https://github.com/mbeddr/build.publish.mps) publishes a marker artifact
+`com.jetbrains.mps:mps-jbr` for each MPS release, and
+[publish-mps-prereleases](https://github.com/mbeddr/publish-mps-prereleases) publishes the same marker for each MPS
+pre-release build. It is a dependency-only POM whose single dependency is the exact `com.jetbrains.jdk:jbr_jcef` version
+that MPS is built with (derived from `mps.runtimeBuild` in the distribution's `build.properties`).
+
+Releases (in `maven-mps`) and pre-releases (in `maven-mps-prereleases`) use the same coordinates; this build picks the
+repository from the shape of the version. This is the same lookup performed when you publish by `mpsVersion`.
 
 ## MPS - JBR table
+
+The table below is a convenience snapshot. Since MPS 2023.3.1 the authoritative mapping is the `mps-jbr` marker artifact
+described above.
 
 | MPS Version | JDK Version | JDK Build | Full JBR string    |
 |-------------|-------------|-----------|--------------------|
@@ -38,5 +60,10 @@ For publishing, run parametrized build in the CI providing `jdkVersion` and `jdk
 | 2022.3      | 17.0.6      | b653.34   | 17.0.6-b653.34     |
 | 2023.2      | 17.0.12     | b1000.54  | 17.0.12-b1000.54   |
 | 2023.3      | 17.0.12     | b1087.25  | 17.0.12-b1087.25   |
+| 2023.3.1    | 17.0.9      | b1087.9   | 17.0.9-b1087.9     |
 | 2024.1      | 17.0.11     | b1207.30  | 17.0.11-b1207.30   |
+| 2024.3      | 21.0.5      | b631.16   | 21.0.5-b631.16     |
 | 2025.1      | 21.0.6      | b895.109  | 21.0.6-b895.109    |
+| 2025.2.1    | 21.0.8      | b1038.71  | 21.0.8-b1038.71    |
+| 2025.3      | 21.0.8      | b1163.69  | 21.0.8-b1163.69    |
+| 2026.1      | 25.0.3      | b329.124  | 25.0.3-b329.124    |

--- a/build.gradle
+++ b/build.gradle
@@ -7,16 +7,33 @@ import de.undercouch.gradle.tasks.download.Download
 import org.gradle.api.publish.maven.internal.publication.MavenPomInternal
 
 group 'com.jetbrains.jdk'
-Provider<String> versionString = provider {
-    if (!project.hasProperty('jdkVersion')) {
-        throw new GradleException("Project property 'jdkVersion' must be set")
-    }
-    if (!project.hasProperty('jdkBuild')) {
-        throw new GradleException("Project property 'jdkBuild' must be set")
+
+// Parses a full JBR version string in one of the following formats:
+//   25.0.3b508.4
+//   25.0.3-b508.4
+//   25.0.3+9-b508.16   (the "+9" part is ignored)
+// into the version part (e.g. "25.0.3") and the build part (e.g. "b508.4").
+def jbrVersionPattern = ~/^(\d+(?:\.\d+)*)(?:\+\d+)?-?(b\d+(?:\.\d+)*)$/
+
+Provider<List<String>> versionParts = provider {
+    if (project.hasProperty('jbrVersion')) {
+        def matcher = jbrVersionPattern.matcher(project.jbrVersion.toString())
+        if (!matcher.matches()) {
+            throw new GradleException("Project property 'jbrVersion' has an unrecognized format: '$jbrVersion'")
+        }
+        return [matcher.group(1), matcher.group(2)]
     }
 
-    "$jdkVersion-$jdkBuild".toString()
+    // 'jdkVersion' and 'jdkBuild' are deprecated; use 'jbrVersion' instead.
+    if (project.hasProperty('jdkVersion') && project.hasProperty('jdkBuild')) {
+        logger.warn("Project properties 'jdkVersion' and 'jdkBuild' are deprecated; use 'jbrVersion' instead")
+        return [project.jdkVersion.toString(), project.jdkBuild.toString()]
+    }
+
+    throw new GradleException("Project property 'jbrVersion' must be set")
 }
+
+Provider<String> versionString = versionParts.map { "${it[0]}-${it[1]}".toString() }
 
 def architectures = [
         'osx-aarch64',
@@ -73,7 +90,7 @@ distroTypes.each { distroType ->
 
     architectures.each { architecture ->
         def downloadTask = tasks.register('get_' + distroType + '_' + architecture, Download) {
-            def fileName = provider { "${distroType}-${jdkVersion}-${architecture}-${jdkBuild}.tar.gz".toString() }
+            def fileName = versionParts.map { "${distroType}-${it[0]}-${architecture}-${it[1]}.tar.gz".toString() }
 
             src fileName.map { "https://cache-redirector.jetbrains.com/intellij-jbr/$it" }
             dest layout.buildDirectory.file(fileName)

--- a/build.gradle
+++ b/build.gradle
@@ -15,22 +15,71 @@ group 'com.jetbrains.jdk'
 // into the version part (e.g. "25.0.3") and the build part (e.g. "b508.4").
 def jbrVersionPattern = ~/^(\d+(?:\.\d+)*)(?:\+\d+)?-?(b\d+(?:\.\d+)*)$/
 
+// Returns the trimmed value of a project property, or null if it is absent or blank. Blank values are treated as unset
+// so that a CI job can pass '-PjbrVersion= -PmpsVersion=2025.1' and have only the non-blank one take effect.
+def trimmedProperty = { String name ->
+    if (!project.hasProperty(name)) {
+        return null
+    }
+    def value = project.getProperty(name)?.toString()?.trim()
+    return value ?: null
+}
+
+// Looks up the JBR version that a given MPS version is built with by reading the 'com.jetbrains.mps:mps-jbr' marker POM.
+// The marker is a dependency-only POM whose single dependency is the matching 'com.jetbrains.jdk:jbr_jcef' version.
+//
+// Both released and pre-release MPS builds publish the marker under the same coordinates but into different
+// repositories, distinguished by the shape of the version:
+//   - releases look like a year, e.g. '2025.1', '2024.3.2', '2026.1-RC1' -> 'maven-mps'
+//   - pre-releases are build numbers, e.g. '261.25134.10210'            -> 'maven-mps-prereleases'
+def resolveJbrVersionFromMps = { String mpsVersion ->
+    def isRelease = mpsVersion ==~ /^\d{4}\..*/
+    def repository = isRelease ? "maven-mps" : "maven-mps-prereleases"
+    def url = "https://artifacts.itemis.cloud/repository/${repository}/com/jetbrains/mps/mps-jbr/${mpsVersion}/mps-jbr-${mpsVersion}.pom"
+    String pom
+    try {
+        pom = new URL(url).text
+    } catch (IOException e) {
+        def hint = isRelease
+                ? "The 'mps-jbr' marker is only published for MPS 2023.3.1 and later; for earlier versions pass 'jbrVersion' directly."
+                : "Ensure a pre-release build publishing the 'mps-jbr' marker exists for this version, or pass 'jbrVersion' directly."
+        throw new GradleException("Could not fetch the JBR marker POM for MPS ${mpsVersion} from ${url}. ${hint}", e)
+    }
+
+    def matcher = pom =~ /(?s)<artifactId>\s*jbr_jcef\s*<\/artifactId>\s*<version>([^<]+)<\/version>/
+    if (!matcher.find()) {
+        throw new GradleException("The JBR marker POM for MPS ${mpsVersion} does not declare a 'jbr_jcef' dependency: ${url}")
+    }
+    return matcher.group(1).trim()
+}
+
 Provider<List<String>> versionParts = provider {
-    if (project.hasProperty('jbrVersion')) {
-        def matcher = jbrVersionPattern.matcher(project.jbrVersion.toString())
+    def jbrVersion = trimmedProperty('jbrVersion')
+    def mpsVersion = trimmedProperty('mpsVersion')
+
+    if (jbrVersion && mpsVersion) {
+        throw new GradleException("Set only one of 'jbrVersion' or 'mpsVersion', not both")
+    }
+
+    def fullVersion = jbrVersion ?: (mpsVersion ? resolveJbrVersionFromMps(mpsVersion) : null)
+    if (fullVersion) {
+        def matcher = jbrVersionPattern.matcher(fullVersion)
         if (!matcher.matches()) {
-            throw new GradleException("Project property 'jbrVersion' has an unrecognized format: '$jbrVersion'")
+            throw new GradleException("JBR version '${fullVersion}' has an unrecognized format" +
+                    (mpsVersion ? " (resolved from MPS ${mpsVersion})" : ""))
         }
         return [matcher.group(1), matcher.group(2)]
     }
 
     // 'jdkVersion' and 'jdkBuild' are deprecated; use 'jbrVersion' instead.
-    if (project.hasProperty('jdkVersion') && project.hasProperty('jdkBuild')) {
+    def jdkVersion = trimmedProperty('jdkVersion')
+    def jdkBuild = trimmedProperty('jdkBuild')
+    if (jdkVersion && jdkBuild) {
         logger.warn("Project properties 'jdkVersion' and 'jdkBuild' are deprecated; use 'jbrVersion' instead")
-        return [project.jdkVersion.toString(), project.jdkBuild.toString()]
+        return [jdkVersion, jdkBuild]
     }
 
-    throw new GradleException("Project property 'jbrVersion' must be set")
+    throw new GradleException("One of 'jbrVersion' or 'mpsVersion' must be set")
 }
 
 Provider<String> versionString = versionParts.map { "${it[0]}-${it[1]}".toString() }


### PR DESCRIPTION
## Summary

Currently the version to publish is given via the `jdkVersion` + `jdkBuild` properties. This PR adds two alternatives and deprecates the two-property form in favor of the first:

- `jbrVersion` — the full JBR version as a single string, e.g. `21.0.6-b895.109` (also accepts formats like `25.0.3+9-b508.16`).
- `mpsVersion` — an MPS version; the matching JBR version is resolved automatically (see below).

`jdkVersion` + `jdkBuild` continue to work.

When `mpsVersion` is set, the JBR version is looked up from the `com.jetbrains.mps:mps-jbr` marker POM (a dependency-only POM whose single dependency is the `jbr_jcef` version the MPS build uses, derived from `mps.runtimeBuild`). This consumes the marker introduced in [build.publish.mps#49](https://github.com/mbeddr/build.publish.mps/pull/49).

Both MPS releases and pre-releases publish the marker under the same coordinates but in different repositories. The build routes by the shape of the version:
- release (e.g. `2025.1`) → `maven-mps`
- pre-release build number (e.g. `261.25134.10210`) → `maven-mps-prereleases`

## Details

- Precedence & guards: `mpsVersion` and `jbrVersion` are mutually exclusive (both set → error). Blank property values are treated as unset, so CI can pass `-PjbrVersion= -PmpsVersion=…` and have only the non-blank one take effect. The `jdkVersion`/`jdkBuild` path is preserved.
- Filled in the MPS - JBR table from the marker artifacts (2023.3.1, 2024.3, 2025.2.1, 2025.3, 2026.1).
- Added a CI job (`publish-by-mps-version`) that runs `publishToMavenLocal -PmpsVersion=2025.1`, mirroring the existing `publish-by-jbr-version` job.

## Follow-up (TeamCity, manual)

The `PublishJdk` build configuration is UI-defined, not in this repo. To use the new path, add an `mpsVersion` parameter and pass `-PjbrVersion=%jbrVersion% -PmpsVersion=%mpsVersion%` on the Gradle runner. Because blanks are treated as unset, leaving one field empty selects the other.

## Testing

- Release `2025.1` → `21.0.6-b895.109` ✅
- `2026.1` → `25.0.3-b329.124` ✅
- `jbrVersion` (incl. `+9-b…` form), `jdkVersion`+`jdkBuild`, and blank-passthrough still work ✅
- both-set / neither-set / pre-marker MPS all fail with clear messages ✅
- Pre-release routing targets `maven-mps-prereleases` (no pre-release marker published yet, so not resolved live)

## Note

This branch also includes the `jbrVersion` commit (`Accept JBR version as a single string property`), which is not yet on `master`, so it is part of this PR's diff.