### PR TITLE
Set the TeamCity build number to the resolved JBR version

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -84,6 +84,18 @@ Provider<List<String>> versionParts = provider {
 
 Provider<String> versionString = versionParts.map { "${it[0]}-${it[1]}".toString() }
 
+// When running under TeamCity, report the resolved JBR version as the build number. Builds triggered by 'mpsVersion'
+// don't know the JBR version up front, so the build number can't be composed from the trigger parameters; setting it
+// here labels every build with the version actually being published. TeamCity reads the service message from stdout.
+// See https://www.jetbrains.com/help/teamcity/service-messages.html#Reporting+Build+Number
+if (System.getenv("TEAMCITY_VERSION")) {
+    gradle.taskGraph.whenReady { graph ->
+        if (graph.allTasks.any { it.name.startsWith("publish") }) {
+            println "##teamcity[buildNumber '${versionString.get()}']"
+        }
+    }
+}
+
 def architectures = [
         'osx-aarch64',
         'osx-x64',


### PR DESCRIPTION
## Why

The `PublishJdk` build number used to be composed from the `jdkVersion` / `jdkBuild` trigger parameters. Those were removed in favour of `jbrVersion` / `mpsVersion`, so the build-number pattern referenced an undefined parameter and the build wouldn't start.

When a build is triggered by `mpsVersion`, the JBR version isn't known until the `mps-jbr` marker POM is fetched, so the build number can't be composed from the trigger parameters at all.

## What

The Gradle build now emits a [`buildNumber` service message](https://www.jetbrains.com/help/teamcity/service-messages.html#Reporting+Build+Number) with the resolved JBR version whenever a `publish*` task runs under TeamCity. Every build — whether triggered by `jbrVersion` or `mpsVersion` — is labelled with the version actually being published.

Guarded so it only fires under TeamCity (`TEAMCITY_VERSION` set) and only when a publish task is in the graph, so non-publish invocations don't force version resolution.

The corresponding TeamCity build-number format has been reset to the default (`%build.counter%`) so the Gradle override takes effect.